### PR TITLE
Bump DAK to v1.10.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.2"),
-        .package(url: "https://github.com/rickhohler/DesignAlgorithmsKit.git", branch: "main"),
+        .package(url: "https://github.com/rickhohler/DesignAlgorithmsKit.git", from: "1.10.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Converted unstable branch dependency to explicit v1.10.0 version tag for deterministic downstream builds.